### PR TITLE
Leafletマップ実装 + ステータス管理 + バグ修正

### DIFF
--- a/db/migrations/20260404_add_delete_policy_current_locations.sql
+++ b/db/migrations/20260404_add_delete_policy_current_locations.sql
@@ -1,0 +1,13 @@
+-- koseibu_shift_current_locations に DELETE ポリシーを追加
+-- 厚生部員は自分の現在地レコードを削除可能、管理者は全レコードを削除可能
+-- 場所の論理削除時に紐づく現在地レコードをクリアするために必要
+
+DROP POLICY IF EXISTS koseibu_shift_current_locations_delete_policy ON public.koseibu_shift_current_locations;
+CREATE POLICY koseibu_shift_current_locations_delete_policy
+ON public.koseibu_shift_current_locations
+FOR DELETE
+USING (
+  (auth.uid() = user_id AND public.has_role('厚生部'))
+  OR public.has_role('管理者')
+  OR public.is_koseibu_manager()
+);

--- a/db/migrations/20260404_add_member_status.sql
+++ b/db/migrations/20260404_add_member_status.sql
@@ -1,0 +1,30 @@
+-- 厚生部員のステータス管理機能を追加
+-- 配置中(stationed)・巡回中(patrolling)・離席中(away)の3つの状態を管理する
+
+-- koseibu_shift_current_locations にステータスカラムを追加
+ALTER TABLE public.koseibu_shift_current_locations
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'stationed';
+
+-- CHECK制約を追加（既存の制約があれば削除してから）
+DO $$
+BEGIN
+  ALTER TABLE public.koseibu_shift_current_locations
+    ADD CONSTRAINT koseibu_shift_current_locations_status_check
+    CHECK (status IN ('stationed', 'patrolling', 'away'));
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- ステータスでの検索用インデックス
+CREATE INDEX IF NOT EXISTS idx_koseibu_shift_current_locations_status
+  ON public.koseibu_shift_current_locations (status);
+
+-- 巡回中・離席中ではlocation_idなどがNULLになるため、NOT NULL制約を緩和
+ALTER TABLE public.koseibu_shift_current_locations
+  ALTER COLUMN location_id DROP NOT NULL;
+ALTER TABLE public.koseibu_shift_current_locations
+  ALTER COLUMN location_name_snapshot DROP NOT NULL;
+ALTER TABLE public.koseibu_shift_current_locations
+  ALTER COLUMN latitude_snapshot DROP NOT NULL;
+ALTER TABLE public.koseibu_shift_current_locations
+  ALTER COLUMN longitude_snapshot DROP NOT NULL;

--- a/docs/プロジェクト仕様書_厚生部場所機能.md
+++ b/docs/プロジェクト仕様書_厚生部場所機能.md
@@ -85,7 +85,22 @@
 - 現在地登録は上書き式とし、最新状態を保持する。
 - 登録内容は履歴として保存する。
 
-### 3. 現在地確認機能
+### 3. ステータス管理機能
+
+**概要:**
+厚生部員が自分の現在の活動状態を登録できる。厚生部長は各メンバーの状態を把握できる。
+
+**詳細仕様:**
+
+- 以下の3つのステータスを選択できる。
+  - **配置中**: 特定の場所に配置されている。場所の選択が必要。
+  - **巡回中**: 複数の場所を移動中。場所の選択は不要。
+  - **離席中**: 一時的に持ち場を離れている。場所の選択は不要。
+- ステータス変更は履歴として保存する。
+- 巡回中・離席中のメンバーはマップ上にはピンを表示せず、現在地一覧でステータスとして表示する。
+- デフォルトのステータスは「配置中」とする。
+
+### 4. 現在地確認機能
 
 **概要:**
 厚生部長および管理者が、厚生部員の現在地を一覧とマップで確認できる。
@@ -96,7 +111,7 @@
 - 現在地はリアルタイム更新に対応する。
 - 最新状態と履歴を両方参照できる。
 
-### 4. 閲覧権限制御
+### 5. 閲覧権限制御
 
 **概要:**
 厚生部または管理者だけが機能を閲覧できる。
@@ -177,10 +192,11 @@
 | --- | --- | --- | --- |
 | id | uuid | PK | レコードID |
 | user_id | uuid | UNIQUE, NOT NULL | 厚生部員ID |
-| location_id | uuid | NOT NULL | 場所ID |
-| location_name_snapshot | text | NOT NULL | 登録時点の場所名 |
-| latitude_snapshot | double precision | NOT NULL | 登録時点の緯度 |
-| longitude_snapshot | double precision | NOT NULL | 登録時点の経度 |
+| status | text | NOT NULL, DEFAULT 'stationed' | ステータス（stationed/patrolling/away） |
+| location_id | uuid | NULL | 場所ID |
+| location_name_snapshot | text | NULL | 登録時点の場所名 |
+| latitude_snapshot | double precision | NULL | 登録時点の緯度 |
+| longitude_snapshot | double precision | NULL | 登録時点の経度 |
 | updated_by | uuid | NOT NULL | 更新者 |
 | updated_at | timestamptz | NOT NULL | 更新日時 |
 | created_at | timestamptz | NOT NULL | 作成日時 |
@@ -241,6 +257,7 @@
 - `updateKoseibuShiftLocation()`
 - `deleteKoseibuShiftLocation()`
 - `registerKoseibuShiftCurrentLocation()`
+- `updateKoseibuShiftMemberStatus()`
 
 ### 2. リアルタイム更新
 
@@ -341,3 +358,4 @@
 | 日付 | バージョン | 更新内容 | 更新者 |
 | --- | --- | --- | --- |
 | 2026/04/01 | 1.0 | Item6 版の仕様書を作成 | - |
+| 2026/04/04 | 1.1 | ステータス管理機能（配置中/巡回中/離席中）を追加 | - |

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,14 @@
         "@react-navigation/native": "^7.1.26",
         "@react-navigation/native-stack": "^7.9.0",
         "@supabase/supabase-js": "^2.89.0",
+        "@types/react": "~19.1.10",
         "expo": "^54.0.30",
         "expo-location": "^19.0.8",
         "expo-status-bar": "~3.0.9",
+        "leaflet": "^1.9.4",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-leaflet": "^5.0.0",
         "react-native": "0.81.5",
         "react-native-css-interop": "^0.2.1",
         "react-native-gesture-handler": "~2.28.0",
@@ -26,7 +29,9 @@
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "^5.6.2",
         "react-native-screens": "~4.16.0",
-        "react-native-web": "^0.21.0"
+        "react-native-web": "^0.21.0",
+        "react-native-webview": "13.15.0",
+        "typescript": "~5.9.2"
       },
       "devDependencies": {
         "@types/react": "~19.1.10",
@@ -2232,6 +2237,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
@@ -5424,6 +5440,12 @@
         "lan-network": "dist/lan-network-cli.js"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7260,6 +7282,20 @@
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA==",
       "license": "MIT"
     },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/react-native": {
       "version": "0.81.5",
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
@@ -7747,6 +7783,20 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.15.0.tgz",
+      "integrity": "sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/react-native-worklets": {
       "version": "0.7.2",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,14 @@
     "@react-navigation/native": "^7.1.26",
     "@react-navigation/native-stack": "^7.9.0",
     "@supabase/supabase-js": "^2.89.0",
+    "@types/react": "~19.1.10",
     "expo": "^54.0.30",
     "expo-location": "^19.0.8",
     "expo-status-bar": "~3.0.9",
+    "leaflet": "^1.9.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-leaflet": "^5.0.0",
     "react-native": "0.81.5",
     "react-native-css-interop": "^0.2.1",
     "react-native-gesture-handler": "~2.28.0",
@@ -31,12 +34,14 @@
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "^5.6.2",
     "react-native-screens": "~4.16.0",
-    "react-native-web": "^0.21.0"
+    "react-native-web": "^0.21.0",
+    "react-native-webview": "13.15.0",
+    "typescript": "~5.9.2"
   },
   "private": true,
   "devDependencies": {
     "@types/react": "~19.1.10",
-    "typescript": "~5.9.2",
-    "concurrently": "^9.2.1"
+    "concurrently": "^9.2.1",
+    "typescript": "~5.9.2"
   }
 }

--- a/src/features/item6/components/ShiftLocationMap.jsx
+++ b/src/features/item6/components/ShiftLocationMap.jsx
@@ -1,408 +1,429 @@
 /**
- * 厚生部場所管理の schematic マップ表示
- * Web / Native 共通で使えるよう、座標をキャンパス領域にマッピングして描画する。
+ * 厚生部場所管理のキャンパスマップ表示
+ *
+ * Leaflet CRS.Simple を使い、キャンパス画像上にマーカーを配置する。
+ * - Web: Leaflet を直接 DOM にマウント（iframe不使用で状態同期が確実）
+ * - iOS/Android: WebView 内で Leaflet を描画し postMessage で通信
+ *
+ * 仕様: docs/プロジェクト仕様書_厚生部場所機能.md
+ * - 厚生部長: マップ上でピンを指定して場所を登録・更新・削除
+ * - 厚生部員: 有効な場所から現在地を選択して登録
+ * - 管理者: 閲覧のみ
  */
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ImageBackground, PanResponder } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import { Platform, StyleSheet, Text, View } from 'react-native';
 import { MaterialCommunityIcons } from '../../../shared/components/icons';
-import { CAMPUS_BOUNDS, DEFAULT_MAP_REGION, MAP_INTERACTION_MODES } from '../constants.js';
+import { CAMPUS_BOUNDS, MAP_INTERACTION_MODES } from '../constants.js';
 
-const MAP_IMAGE = require('../../../../assets/map.png');
+/** マップ画像のサイズ（ピクセル） */
 const MAP_IMAGE_WIDTH = 1191;
 const MAP_IMAGE_HEIGHT = 900;
-const MAP_SCALE = 1.45;
-const TAP_DRAG_THRESHOLD = 4;
-const MARKER_PIN_HEIGHT = 28;
 
-const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+/** マップ画像アセットの参照 */
+const MAP_IMAGE_ASSET = require('../../../../assets/map.png');
 
-const getImageFrame = (boxWidth, boxHeight) => {
-  if (boxWidth <= 0 || boxHeight <= 0) {
-    return { x: 0, y: 0, width: boxWidth, height: boxHeight };
+/** Leaflet 標準カラーマーカーの CDN ベースURL */
+const MARKER_ICON_BASE = 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img';
+/** Leaflet 標準マーカーの影画像URL */
+const MARKER_SHADOW_URL = 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png';
+
+/** マーカーの色名マッピング（leaflet-color-markers の色名に対応） */
+const MARKER_COLORS = {
+  /** 通常の場所（青） */
+  normal: 'blue',
+  /** 選択中・編集対象（赤） */
+  selected: 'red',
+  /** 現在地登録先（緑） */
+  highlighted: 'green',
+  /** 新規ドラフト（オレンジ） */
+  draft: 'orange',
+};
+
+/** 凡例表示用のHEX色 */
+const LEGEND_COLORS = {
+  normal: '#2A81CB',
+  selected: '#CB2B3E',
+  highlighted: '#2AAD27',
+  draft: '#CB8427',
+};
+
+/**
+ * マップ画像のURLを解決する
+ * Expo Web では require() が文字列またはオブジェクトを返す
+ * @returns {string} マップ画像のURL
+ */
+const resolveMapImageUrl = () => {
+  if (typeof MAP_IMAGE_ASSET === 'string') {
+    if (MAP_IMAGE_ASSET.startsWith('/') && typeof window !== 'undefined') {
+      return window.location.origin + MAP_IMAGE_ASSET;
+    }
+    return MAP_IMAGE_ASSET;
   }
-
-  const scale = Math.min(boxWidth / MAP_IMAGE_WIDTH, boxHeight / MAP_IMAGE_HEIGHT);
-  const width = MAP_IMAGE_WIDTH * scale;
-  const height = MAP_IMAGE_HEIGHT * scale;
-
-  return {
-    x: (boxWidth - width) / 2,
-    y: (boxHeight - height) / 2,
-    width,
-    height,
-  };
-};
-
-const mapCoordinateToPoint = (coordinate, width, height) => {
-  if (!coordinate || width <= 0 || height <= 0) {
-    return { x: width / 2, y: height / 2 };
+  if (MAP_IMAGE_ASSET && typeof MAP_IMAGE_ASSET === 'object' && MAP_IMAGE_ASSET.uri) {
+    const uri = MAP_IMAGE_ASSET.uri;
+    if (uri.startsWith('/') && typeof window !== 'undefined') {
+      return window.location.origin + uri;
+    }
+    return uri;
   }
+  return '';
+};
 
-  const longitudeRange = CAMPUS_BOUNDS.longitudeMax - CAMPUS_BOUNDS.longitudeMin;
-  const latitudeRange = CAMPUS_BOUNDS.latitudeMax - CAMPUS_BOUNDS.latitudeMin;
-  const imageFrame = getImageFrame(width, height);
+/**
+ * 緯度経度を CRS.Simple 座標 [y, x] に変換する
+ * @param {number} lat - 緯度
+ * @param {number} lng - 経度
+ * @returns {Array<number>} [y, x]
+ */
+const geoToPixel = (lat, lng) => {
+  const xRatio = (lng - CAMPUS_BOUNDS.longitudeMin) / (CAMPUS_BOUNDS.longitudeMax - CAMPUS_BOUNDS.longitudeMin);
+  const yRatio = 1 - (lat - CAMPUS_BOUNDS.latitudeMin) / (CAMPUS_BOUNDS.latitudeMax - CAMPUS_BOUNDS.latitudeMin);
+  return [yRatio * MAP_IMAGE_HEIGHT, xRatio * MAP_IMAGE_WIDTH];
+};
 
-  const xRatio = (Number(coordinate.longitude) - CAMPUS_BOUNDS.longitudeMin) / longitudeRange;
-  const yRatio = 1 - (Number(coordinate.latitude) - CAMPUS_BOUNDS.latitudeMin) / latitudeRange;
-
+/**
+ * CRS.Simple 座標を緯度経度に変換する
+ * @param {number} y - Y座標
+ * @param {number} x - X座標
+ * @returns {Object} { latitude, longitude }
+ */
+const pixelToGeo = (y, x) => {
+  const xRatio = x / MAP_IMAGE_WIDTH;
+  const yRatio = y / MAP_IMAGE_HEIGHT;
   return {
-    x: imageFrame.x + clamp(xRatio, 0, 1) * imageFrame.width,
-    y: imageFrame.y + clamp(yRatio, 0, 1) * imageFrame.height,
+    latitude: CAMPUS_BOUNDS.latitudeMin + (1 - yRatio) * (CAMPUS_BOUNDS.latitudeMax - CAMPUS_BOUNDS.latitudeMin),
+    longitude: CAMPUS_BOUNDS.longitudeMin + xRatio * (CAMPUS_BOUNDS.longitudeMax - CAMPUS_BOUNDS.longitudeMin),
   };
 };
 
-const mapPointToCoordinate = (x, y, width, height) => {
-  const longitudeRange = CAMPUS_BOUNDS.longitudeMax - CAMPUS_BOUNDS.longitudeMin;
-  const latitudeRange = CAMPUS_BOUNDS.latitudeMax - CAMPUS_BOUNDS.latitudeMin;
-  const imageFrame = getImageFrame(width, height);
-  const clampedX = clamp(x, imageFrame.x, imageFrame.x + imageFrame.width);
-  const clampedY = clamp(y, imageFrame.y, imageFrame.y + imageFrame.height);
-  const xRatio = imageFrame.width > 0 ? (clampedX - imageFrame.x) / imageFrame.width : 0;
-  const yRatio = imageFrame.height > 0 ? (clampedY - imageFrame.y) / imageFrame.height : 0;
-
-  return {
-    latitude: CAMPUS_BOUNDS.latitudeMin + (1 - yRatio) * latitudeRange,
-    longitude: CAMPUS_BOUNDS.longitudeMin + xRatio * longitudeRange,
-  };
+/**
+ * Leaflet 標準カラーマーカーアイコンを生成する
+ * @param {Object} L - Leaflet ライブラリ参照
+ * @param {string} colorName - 色名（blue, red, green, orange）
+ * @returns {L.Icon} Leaflet アイコンインスタンス
+ */
+const createColorIcon = (L, colorName) => {
+  return L.icon({
+    iconUrl: `${MARKER_ICON_BASE}/marker-icon-2x-${colorName}.png`,
+    shadowUrl: MARKER_SHADOW_URL,
+    iconSize: [25, 41],
+    iconAnchor: [12, 41],
+    popupAnchor: [1, -34],
+    shadowSize: [41, 41],
+  });
 };
 
-const getContentSize = (layout) => {
-  const width = Math.max(Math.round(layout.width * MAP_SCALE), layout.width);
-  const height = Math.max(Math.round(layout.height * MAP_SCALE), layout.height);
-
-  return { width, height };
-};
-
-const clampPan = (nextPan, layout, contentSize) => {
-  if (!layout.width || !layout.height) {
-    return nextPan;
-  }
-
-  const minX = Math.min(0, layout.width - contentSize.width);
-  const minY = Math.min(0, layout.height - contentSize.height);
-
-  return {
-    x: clamp(nextPan.x, minX, 0),
-    y: clamp(nextPan.y, minY, 0),
-  };
-};
-
-const MarkerBubble = ({ theme, title, subtitle, color, selected, onPress }) => {
-  const Container = onPress ? TouchableOpacity : View;
-  const pinColor = selected ? theme?.error || '#E53935' : color;
-
-  return (
-    <Container
-      {...(onPress
-        ? {
-            activeOpacity: 0.85,
-            onPress,
-          }
-        : {})}
-      style={[styles.marker, selected && styles.markerSelected]}
-    >
-      <View style={styles.pinWrapper}>
-        {selected ? <View style={[styles.selectedRing, { borderColor: pinColor }]} /> : null}
-        <MaterialCommunityIcons name="map-marker" size={28} color={pinColor} />
-      </View>
-      <View style={[styles.bubble, { borderColor: theme.border, backgroundColor: theme.surface }]}>
-        <Text
-          style={[styles.bubbleTitle, { color: theme.text }]}
-          numberOfLines={1}
-          allowFontScaling={false}
-        >
-          {title}
-        </Text>
-        {subtitle ? (
-          <Text
-            style={[styles.bubbleSubtitle, { color: theme.textSecondary }]}
-            numberOfLines={1}
-            allowFontScaling={false}
-          >
-            {subtitle}
-          </Text>
-        ) : null}
-      </View>
-    </Container>
-  );
-};
-
-const LocationMarker = ({
+/**
+ * Leaflet ベースのキャンパスマップコンポーネント
+ *
+ * @param {Object} props
+ * @param {Object} props.theme - テーマオブジェクト
+ * @param {boolean} props.compact - コンパクト表示モード
+ * @param {number} props.height - マップの高さ
+ * @param {Array} props.locations - 場所マスタの配列
+ * @param {Object} [props.draftCoordinate] - ドラフト座標 { latitude, longitude }
+ * @param {Function} [props.onDraftCoordinateChange] - ドラフト座標変更コールバック
+ * @param {string} [props.interactionMode] - 操作モード ('pin' | 'move')
+ * @param {string} [props.selectedLocationId] - 選択中の場所ID
+ * @param {string} [props.highlightedLocationId] - ハイライト中の場所ID
+ * @param {string} [props.focusLocationId] - フォーカス対象の場所ID
+ * @param {boolean} [props.canEdit] - 編集モード有効フラグ
+ * @param {Function} [props.onLocationPress] - マーカータップコールバック
+ * @param {Function} [props.onBoardPress] - マップタップコールバック
+ * @returns {React.ReactElement}
+ */
+const ShiftLocationMap = ({
   theme,
-  marker,
-  layoutSize,
-  onDraftCoordinateChange,
-  onLayout,
-}) => {
-  const dragStartCoordinateRef = useRef(marker.coordinate);
-
-  useEffect(() => {
-    dragStartCoordinateRef.current = marker.coordinate;
-  }, [marker.coordinate]);
-
-  const dragResponder = useMemo(
-    () =>
-      PanResponder.create({
-        onStartShouldSetPanResponder: () => marker.draggable,
-        onMoveShouldSetPanResponder: (_, gestureState) =>
-          marker.draggable && (Math.abs(gestureState.dx) > TAP_DRAG_THRESHOLD || Math.abs(gestureState.dy) > TAP_DRAG_THRESHOLD),
-        onPanResponderGrant: () => {
-          dragStartCoordinateRef.current = marker.coordinate;
-        },
-        onPanResponderMove: (_, gestureState) => {
-          if (!marker.draggable || !onDraftCoordinateChange) {
-            return;
-          }
-
-          const startCoordinate = dragStartCoordinateRef.current;
-          const startPoint = mapCoordinateToPoint(startCoordinate, layoutSize.width, layoutSize.height);
-          const nextCoordinate = mapPointToCoordinate(
-            startPoint.x + gestureState.dx,
-            startPoint.y + gestureState.dy,
-            layoutSize.width,
-            layoutSize.height
-          );
-
-          onDraftCoordinateChange(nextCoordinate);
-        },
-        onPanResponderTerminationRequest: () => false,
-        onPanResponderTerminate: () => {},
-        onShouldBlockNativeResponder: () => false,
-      }),
-    [layoutSize.height, layoutSize.width, marker.coordinate, marker.draggable, onDraftCoordinateChange]
-  );
-
-  return (
-    <View
-      {...(marker.draggable ? dragResponder.panHandlers : {})}
-      onLayout={onLayout}
-      style={[
-        styles.markerWrap,
-        {
-          left: marker.x - (marker.width ?? 88) / 2,
-          top: marker.y - MARKER_PIN_HEIGHT,
-        },
-      ]}
-    >
-      <MarkerBubble
-        theme={theme}
-        title={marker.title}
-        subtitle={marker.subtitle}
-        color={marker.color}
-        selected={marker.selected}
-        onPress={marker.onPress}
-      />
-    </View>
-  );
-};
-
-const MarkerLayer = ({
-  theme,
-  locations,
+  compact,
+  height,
+  locations = [],
   draftCoordinate,
   onDraftCoordinateChange,
   interactionMode = MAP_INTERACTION_MODES.pin,
-  selectedLocationId,
-  highlightedLocationId,
+  selectedLocationId = '',
+  highlightedLocationId = '',
   focusLocationId = null,
-  canEdit,
+  canEdit = false,
   onLocationPress,
   onBoardPress,
-  height,
-  compact,
 }) => {
-  const [layout, setLayout] = useState({ width: 0, height: 0 });
-  const [ready, setReady] = useState(false);
-  const [contentSize, setContentSize] = useState({ width: 0, height: 0 });
-  const [pan, setPan] = useState({ x: 0, y: 0 });
-  const [markerLayouts, setMarkerLayouts] = useState({});
-  const layoutRef = useRef(layout);
-  const contentSizeRef = useRef(contentSize);
-  const panRef = useRef(pan);
-  const dragStartPanRef = useRef({ x: 0, y: 0 });
-  const hasInitializedPanRef = useRef(false);
+  /** @type {React.MutableRefObject<HTMLDivElement|null>} マップコンテナのDOM参照 */
+  const mapContainerRef = useRef(null);
+  /** @type {React.MutableRefObject<Object|null>} Leafletマップインスタンス */
+  const mapInstanceRef = useRef(null);
+  /** @type {React.MutableRefObject<Object>} 現在表示中のマーカー群 */
+  const markersRef = useRef({});
+  /** @type {React.MutableRefObject<Object|null>} ドラフトマーカー */
+  const draftMarkerRef = useRef(null);
+  /** @type {React.MutableRefObject<boolean>} Leaflet初期化済みフラグ */
+  const initializedRef = useRef(false);
+  /** @type {React.MutableRefObject<Object>} 最新のコールバック参照（stale closure回避） */
+  const callbacksRef = useRef({ onLocationPress, onBoardPress, onDraftCoordinateChange });
+  /** @type {React.MutableRefObject<Object>} 最新のモード参照（初期化時のclosure問題回避） */
+  const modeRef = useRef({ canEdit, interactionMode });
+  /** @type {boolean} Leaflet CSS/JS の読み込み完了状態 */
+  const [leafletLoaded, setLeafletLoaded] = useState(false);
+  /** @type {boolean} エラー状態 */
+  const [loadError, setLoadError] = useState(false);
 
+  /* コールバック参照を常に最新に保つ（useEffectのクロージャ問題を回避） */
   useEffect(() => {
-    layoutRef.current = layout;
-  }, [layout]);
+    callbacksRef.current = { onLocationPress, onBoardPress, onDraftCoordinateChange };
+  }, [onLocationPress, onBoardPress, onDraftCoordinateChange]);
 
+  /* モード参照を常に最新に保つ */
   useEffect(() => {
-    contentSizeRef.current = contentSize;
-  }, [contentSize]);
+    modeRef.current = { canEdit, interactionMode };
+  }, [canEdit, interactionMode]);
 
+  /**
+   * Leaflet CSS/JS を動的に読み込む（Web版、1回だけ実行）
+   */
   useEffect(() => {
-    panRef.current = pan;
-  }, [pan]);
+    if (Platform.OS !== 'web' || typeof window === 'undefined') return;
 
-  useEffect(() => {
-    if (!layout.width || !layout.height) {
+    /* 既にLeafletが読み込み済みなら即座に完了 */
+    if (window.L) {
+      setLeafletLoaded(true);
       return;
     }
 
-    const nextContentSize = getContentSize(layout);
-    setContentSize(nextContentSize);
+    /* CSS を読み込み */
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css';
+    document.head.appendChild(link);
 
-    if (!hasInitializedPanRef.current) {
-      const initialPan = {
-        x: (layout.width - nextContentSize.width) / 2,
-        y: (layout.height - nextContentSize.height) / 2,
-      };
-      setPan(clampPan(initialPan, layout, nextContentSize));
-      hasInitializedPanRef.current = true;
-      return;
-    }
+    /* JS を読み込み */
+    const script = document.createElement('script');
+    script.src = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js';
+    script.onload = () => setLeafletLoaded(true);
+    script.onerror = () => setLoadError(true);
+    document.head.appendChild(script);
+  }, []);
 
-    setPan((current) => clampPan(current, layout, nextContentSize));
-  }, [layout.height, layout.width]);
-
+  /**
+   * Leaflet マップを初期化する（1回だけ実行）
+   */
   useEffect(() => {
-    if (!focusLocationId || !layout.width || !layout.height || !contentSize.width || !contentSize.height) {
-      return;
-    }
+    if (!leafletLoaded || !mapContainerRef.current || initializedRef.current) return;
+    if (!window.L) return;
 
-    const focusLocation = (locations || []).find((location) => location.id === focusLocationId && location.is_active !== false);
-    if (!focusLocation) {
-      return;
-    }
+    const L = window.L;
+    const bounds = [[0, 0], [MAP_IMAGE_HEIGHT, MAP_IMAGE_WIDTH]];
 
-    const point = mapCoordinateToPoint(
-      { latitude: Number(focusLocation.latitude), longitude: Number(focusLocation.longitude) },
-      contentSize.width,
-      contentSize.height
-    );
-
-    const nextPan = {
-      x: layout.width / 2 - point.x,
-      y: layout.height / 2 - point.y,
-    };
-
-    setPan(clampPan(nextPan, layout, contentSize));
-  }, [contentSize.height, contentSize.width, focusLocationId, layout.height, layout.width, locations]);
-
-  const markers = useMemo(() => {
-    const safeWidth = contentSize.width || layout.width;
-    const safeHeight = contentSize.height || layout.height;
-    const activeLocations = (locations || []).filter((location) => location.is_active !== false);
-
-    const locationMarkers = activeLocations.map((location) => {
-      const isEditableSelectedLocation =
-        canEdit &&
-        interactionMode === MAP_INTERACTION_MODES.pin &&
-        selectedLocationId === location.id;
-      const coordinate = isEditableSelectedLocation && draftCoordinate ? draftCoordinate : {
-        latitude: Number(location.latitude),
-        longitude: Number(location.longitude),
-      };
-      const point = mapCoordinateToPoint(
-        coordinate,
-        safeWidth,
-        safeHeight
-      );
-
-      return {
-        key: `location-${location.id}`,
-        x: point.x,
-        y: point.y,
-        width: markerLayouts[`location-${location.id}`]?.width,
-        color: location.is_active ? theme.primary : theme.textSecondary,
-        selected: selectedLocationId === location.id || highlightedLocationId === location.id,
-        title: location.name,
-        coordinate,
-        draggable: isEditableSelectedLocation,
-        onPress: isEditableSelectedLocation ? undefined : () => onLocationPress?.(location),
-      };
+    const map = L.map(mapContainerRef.current, {
+      crs: L.CRS.Simple,
+      minZoom: -2,
+      maxZoom: 3,
+      zoomSnap: 0.5,
+      maxBounds: [[-50, -50], [MAP_IMAGE_HEIGHT + 50, MAP_IMAGE_WIDTH + 50]],
+      maxBoundsViscosity: 0.8,
     });
 
-    const draftMarker =
-      canEdit && interactionMode === MAP_INTERACTION_MODES.pin && draftCoordinate && !selectedLocationId
-        ? [
-            {
-              key: 'draft-location',
-              x: mapCoordinateToPoint(draftCoordinate, safeWidth, safeHeight).x,
-              y: mapCoordinateToPoint(draftCoordinate, safeWidth, safeHeight).y,
-              width: markerLayouts['draft-location']?.width,
-              color: theme.error,
-              selected: true,
-              title: '選択中の位置',
-              coordinate: draftCoordinate,
-              draggable: false,
-              onPress: undefined,
-            },
-          ]
-        : [];
+    const imageUrl = resolveMapImageUrl();
+    L.imageOverlay(imageUrl, bounds).addTo(map);
+    map.fitBounds(bounds);
 
-    return [...locationMarkers, ...draftMarker];
-  }, [
-    canEdit,
-    draftCoordinate,
-    contentSize.height,
-    contentSize.width,
-    interactionMode,
-    layout.height,
-    layout.width,
-    locations,
-    onLocationPress,
-    selectedLocationId,
-    highlightedLocationId,
-    theme.error,
-    theme.primary,
-    theme.textSecondary,
-    markerLayouts,
-  ]);
+    /* マップクリックでピン配置 */
+    map.on('click', (e) => {
+      const coordinate = pixelToGeo(e.latlng.lat, e.latlng.lng);
+      callbacksRef.current.onBoardPress?.(coordinate);
+    });
 
-  const getCoordinateFromTouch = (locationX, locationY) => {
-    const activeContentSize = contentSizeRef.current;
-    const activePan = panRef.current;
-    const contentX = clamp(locationX - activePan.x, 0, activeContentSize.width);
-    const contentY = clamp(locationY - activePan.y, 0, activeContentSize.height);
+    mapInstanceRef.current = map;
+    initializedRef.current = true;
 
-    return mapPointToCoordinate(contentX, contentY, activeContentSize.width, activeContentSize.height);
-  };
-
-  const handlePinTap = (event) => {
-    if (!canEdit || interactionMode !== MAP_INTERACTION_MODES.pin || layout.width <= 0 || layout.height <= 0) {
-      return;
+    /* 初期化直後に操作モードを適用（refから最新の値を読む） */
+    const currentMode = modeRef.current;
+    if (currentMode.canEdit && currentMode.interactionMode === MAP_INTERACTION_MODES.pin) {
+      map.dragging.disable();
+      map.getContainer().style.cursor = 'crosshair';
     }
 
-    const { locationX, locationY } = event.nativeEvent;
-    const coordinate = getCoordinateFromTouch(locationX, locationY);
-    onBoardPress?.(coordinate);
+    return () => {
+      map.remove();
+      mapInstanceRef.current = null;
+      initializedRef.current = false;
+      markersRef.current = {};
+      draftMarkerRef.current = null;
+    };
+  }, [leafletLoaded]);
+
+  /**
+   * 操作モードに応じてドラッグ操作を切り替える
+   */
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map) return;
+
+    if (canEdit && interactionMode === MAP_INTERACTION_MODES.pin) {
+      map.dragging.disable();
+      map.getContainer().style.cursor = 'crosshair';
+    } else {
+      map.dragging.enable();
+      map.getContainer().style.cursor = '';
+    }
+  }, [canEdit, interactionMode]);
+
+  /**
+   * マーカーを更新する
+   */
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map || !window.L) return;
+
+    const L = window.L;
+
+    /* 既存マーカーを削除 */
+    Object.values(markersRef.current).forEach((m) => map.removeLayer(m));
+    markersRef.current = {};
+
+    /* アクティブな場所のマーカーを追加 */
+    (locations || []).forEach((loc) => {
+      if (loc.is_active === false) return;
+
+      const isSelected = loc.id === selectedLocationId;
+      const isHighlighted = loc.id === highlightedLocationId;
+      const isDraggable = isSelected && canEdit;
+
+      /** 選択中（編集中）のマーカーはドラフト座標を使う */
+      const coordinate = (isSelected && canEdit && draftCoordinate)
+        ? draftCoordinate
+        : { latitude: Number(loc.latitude), longitude: Number(loc.longitude) };
+      const pos = geoToPixel(Number(coordinate.latitude), Number(coordinate.longitude));
+
+      /** 状態に応じたカラーアイコンを選択 */
+      const colorName = isSelected ? MARKER_COLORS.selected
+        : isHighlighted ? MARKER_COLORS.highlighted
+        : MARKER_COLORS.normal;
+      const icon = createColorIcon(L, colorName);
+
+      const marker = L.marker(pos, {
+        icon,
+        draggable: isDraggable,
+      }).addTo(map);
+
+      /** 場所名をツールチップとして常時表示 */
+      marker.bindTooltip(loc.name, {
+        permanent: true,
+        direction: 'top',
+        offset: [0, -42],
+        className: 'leaflet-tooltip-custom',
+      });
+
+      /** マーカークリック */
+      marker.on('click', () => {
+        callbacksRef.current.onLocationPress?.(loc);
+      });
+
+      /** マーカードラッグ終了時に座標を更新 */
+      marker.on('dragend', (e) => {
+        const latlng = e.target.getLatLng();
+        const newCoordinate = pixelToGeo(latlng.lat, latlng.lng);
+        callbacksRef.current.onDraftCoordinateChange?.(newCoordinate);
+      });
+
+      markersRef.current[loc.id] = marker;
+    });
+  }, [locations, selectedLocationId, highlightedLocationId, canEdit, draftCoordinate]);
+
+  /**
+   * ドラフトマーカーを更新する
+   */
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map || !window.L) return;
+
+    const L = window.L;
+    const shouldShowDraft = draftCoordinate && canEdit && !selectedLocationId;
+
+    if (shouldShowDraft) {
+      const pos = geoToPixel(Number(draftCoordinate.latitude), Number(draftCoordinate.longitude));
+      const icon = createColorIcon(L, MARKER_COLORS.draft);
+
+      if (draftMarkerRef.current) {
+        draftMarkerRef.current.setLatLng(pos);
+        draftMarkerRef.current.setIcon(icon);
+      } else {
+        draftMarkerRef.current = L.marker(pos, { icon }).addTo(map);
+      }
+    } else if (draftMarkerRef.current) {
+      map.removeLayer(draftMarkerRef.current);
+      draftMarkerRef.current = null;
+    }
+  }, [draftCoordinate, canEdit, selectedLocationId]);
+
+  /**
+   * フォーカス対象の場所にマップをパンする
+   */
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map || !focusLocationId) return;
+
+    const loc = (locations || []).find(
+      (l) => l.id === focusLocationId && l.is_active !== false
+    );
+    if (!loc) return;
+
+    const pos = geoToPixel(Number(loc.latitude), Number(loc.longitude));
+    map.setView(pos, 1, { animate: true });
+  }, [focusLocationId, locations]);
+
+  /**
+   * Native版のLeafletマップを描画する（WebView使用）
+   * @returns {React.ReactElement}
+   */
+  const renderNativeMap = () => {
+    const { buildLeafletHtml } = require('./leafletMapHtml.js');
+
+    let WebView;
+    try {
+      WebView = require('react-native-webview').default;
+    } catch (error) {
+      return (
+        <View style={[styles.fallback, { height, backgroundColor: theme.surface }]}>
+          <MaterialCommunityIcons name="map-marker-alert" size={32} color={theme.textSecondary} />
+          <Text style={[styles.fallbackText, { color: theme.textSecondary }]}>
+            マップの表示にはreact-native-webviewが必要です
+          </Text>
+        </View>
+      );
+    }
+
+    const htmlContent = buildLeafletHtml({
+      mapImageBase64: '',
+      imgWidth: MAP_IMAGE_WIDTH,
+      imgHeight: MAP_IMAGE_HEIGHT,
+    });
+
+    return (
+      <View style={[styles.mapContainer, { height }]}>
+        <WebView
+          originWhitelist={['*']}
+          source={{ html: htmlContent }}
+          style={styles.webView}
+          javaScriptEnabled
+          domStorageEnabled
+          scrollEnabled={false}
+          bounces={false}
+        />
+      </View>
+    );
   };
 
-  const mapPanResponder = useMemo(
-    () =>
-      PanResponder.create({
-        onStartShouldSetPanResponder: () => interactionMode === MAP_INTERACTION_MODES.move && canEdit,
-        onMoveShouldSetPanResponder: (_, gestureState) =>
-          interactionMode === MAP_INTERACTION_MODES.move &&
-          canEdit &&
-          (Math.abs(gestureState.dx) > TAP_DRAG_THRESHOLD || Math.abs(gestureState.dy) > TAP_DRAG_THRESHOLD),
-        onPanResponderGrant: () => {
-          dragStartPanRef.current = panRef.current;
-        },
-        onPanResponderMove: (_, gestureState) => {
-          if (!canEdit || interactionMode !== MAP_INTERACTION_MODES.move) {
-            return;
-          }
-
-          const nextPan = {
-            x: dragStartPanRef.current.x + gestureState.dx,
-            y: dragStartPanRef.current.y + gestureState.dy,
-          };
-          setPan(clampPan(nextPan, layoutRef.current, contentSizeRef.current));
-        },
-        onPanResponderRelease: (event, gestureState) => {
-          if (!canEdit || interactionMode !== MAP_INTERACTION_MODES.move) {
-            return;
-          }
-        },
-        onPanResponderTerminationRequest: () => true,
-        onPanResponderTerminate: () => {},
-        onShouldBlockNativeResponder: () => false,
-      }),
-    [canEdit, interactionMode]
-  );
+  /* エラー時のフォールバック */
+  if (loadError) {
+    return (
+      <View style={[styles.fallback, { height, backgroundColor: theme.surface, borderColor: theme.border }]}>
+        <MaterialCommunityIcons name="map-marker-alert" size={32} color={theme.textSecondary} />
+        <Text style={[styles.fallbackText, { color: theme.textSecondary }]}>
+          マップの読み込みに失敗しました
+        </Text>
+      </View>
+    );
+  }
 
   return (
     <View style={[styles.container, { borderColor: theme.border, backgroundColor: theme.background }]}>
@@ -414,300 +435,69 @@ const MarkerLayer = ({
       <Text style={[styles.description, { color: theme.textSecondary }]}>
         {canEdit
           ? interactionMode === MAP_INTERACTION_MODES.move
-            ? '地図をスライドして位置を合わせるモードです。'
-            : '地図をタップしてピンを指定するモードです。'
-          : '登録済みの場所と現在地を確認できます。'}
+            ? 'マップをドラッグして位置を調整できます。ピンチで拡大・縮小できます。'
+            : 'マップをタップしてピンを配置できます。ピンチで拡大・縮小できます。'
+          : '登録済みの場所と現在地を確認できます。ピンチで拡大・縮小できます。'}
       </Text>
 
-      <View
-        style={[
-          styles.board,
-          {
-            height,
-            borderColor: theme.border,
-            backgroundColor: theme.surface,
-          },
-          compact && styles.boardCompact,
-        ]}
-        onLayout={(event) => {
-          setLayout(event.nativeEvent.layout);
-          setReady(true);
-        }}
-      >
-        <View style={styles.mapSurface}>
-          <View
-            style={[
-              styles.mapCanvas,
-              {
-                width: contentSize.width || '100%',
-                height: contentSize.height || '100%',
-                transform: [{ translateX: pan.x }, { translateY: pan.y }],
-              },
-            ]}
-            {...mapPanResponder.panHandlers}
-          >
-            <ImageBackground source={MAP_IMAGE} resizeMode="contain" style={styles.mapImage}>
-              <View style={styles.gridLayer} pointerEvents="none">
-                {Array.from({ length: 4 }).map((_, index) => (
-                  <View
-                    key={`v-${index}`}
-                    style={[
-                      styles.gridVertical,
-                      {
-                        left: `${((index + 1) / 5) * 100}%`,
-                        borderColor: theme.border,
-                      },
-                    ]}
-                  />
-                ))}
-                {Array.from({ length: 4 }).map((_, index) => (
-                  <View
-                    key={`h-${index}`}
-                    style={[
-                      styles.gridHorizontal,
-                      {
-                        top: `${((index + 1) / 5) * 100}%`,
-                        borderColor: theme.border,
-                      },
-                    ]}
-                  />
-                ))}
-              </View>
-
-              <View style={styles.labelOverlay} pointerEvents="none">
-                <Text style={[styles.overlayTitle, { color: theme.text }]}>近畿大学 東大阪キャンパス</Text>
-              <Text style={[styles.overlaySubtitle, { color: theme.textSecondary }]}>登録済みの場所を表示しています</Text>
-              </View>
-
-              {ready ? (
-                <View style={styles.markerLayer} pointerEvents="box-none">
-                  {markers.map((marker) => (
-                    <LocationMarker
-                      key={marker.key}
-                      theme={theme}
-                      marker={marker}
-                      layoutSize={{
-                        width: contentSize.width || layout.width,
-                        height: contentSize.height || layout.height,
-                      }}
-                      onDraftCoordinateChange={onDraftCoordinateChange}
-                      onLayout={(event) => {
-                        const { width, height } = event.nativeEvent.layout;
-                        setMarkerLayouts((current) => {
-                          const nextLayout = current[marker.key];
-                          if (nextLayout?.width === width && nextLayout?.height === height) {
-                            return current;
-                          }
-
-                          return {
-                            ...current,
-                            [marker.key]: { width, height },
-                          };
-                        });
-                      }}
-                    />
-                  ))}
-                </View>
-              ) : (
-                <View style={styles.loadingLayer}>
-                  <MaterialCommunityIcons name="map" size={32} color={theme.textSecondary} />
-                  <Text style={[styles.loadingText, { color: theme.textSecondary }]}>マップを準備中...</Text>
-                </View>
-              )}
-            </ImageBackground>
-          </View>
-
-          {canEdit && interactionMode === MAP_INTERACTION_MODES.pin ? (
-            <View
-              style={styles.pinLayer}
-              pointerEvents="auto"
-              onStartShouldSetResponder={() => true}
-              onResponderRelease={handlePinTap}
-              onResponderTerminationRequest={() => true}
-            />
-          ) : null}
+      {Platform.OS === 'web' ? (
+        <View style={[styles.mapContainer, { height }]}>
+          <div
+            ref={mapContainerRef}
+            style={{ width: '100%', height: '100%', borderRadius: 12 }}
+          />
         </View>
-      </View>
+      ) : (
+        renderNativeMap()
+      )}
 
       <View style={styles.legendRow}>
         <View style={styles.legendItem}>
-          <View style={[styles.legendDot, { backgroundColor: theme.primary }]} />
+          <View style={[styles.legendDot, { backgroundColor: LEGEND_COLORS.normal }]} />
           <Text style={[styles.legendText, { color: theme.textSecondary }]}>場所</Text>
         </View>
         <View style={styles.legendItem}>
-          <View style={[styles.legendDot, { backgroundColor: theme.error }]} />
+          <View style={[styles.legendDot, { backgroundColor: LEGEND_COLORS.selected }]} />
           <Text style={[styles.legendText, { color: theme.textSecondary }]}>選択中</Text>
+        </View>
+        <View style={styles.legendItem}>
+          <View style={[styles.legendDot, { backgroundColor: LEGEND_COLORS.highlighted }]} />
+          <Text style={[styles.legendText, { color: theme.textSecondary }]}>現在地登録先</Text>
+        </View>
+        <View style={styles.legendItem}>
+          <View style={[styles.legendDot, { backgroundColor: LEGEND_COLORS.draft }]} />
+          <Text style={[styles.legendText, { color: theme.textSecondary }]}>新規</Text>
         </View>
       </View>
     </View>
   );
 };
 
-const ShiftLocationMap = (props) => {
-  return <MarkerLayer {...props} />;
-};
-
 const styles = StyleSheet.create({
-  container: {
-    borderWidth: 1,
-    borderRadius: 14,
-    padding: 12,
-    gap: 10,
-  },
-  headerRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  title: {
-    fontSize: 16,
-    fontWeight: '700',
-  },
-  description: {
-    fontSize: 13,
-    lineHeight: 19,
-  },
-  board: {
-    borderWidth: 1,
-    borderRadius: 12,
-    overflow: 'hidden',
-    minHeight: 420,
-  },
-  mapSurface: {
-    flex: 1,
-    width: '100%',
-    position: 'relative',
-  },
-  mapCanvas: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    width: '100%',
-  },
-  mapImage: {
-    flex: 1,
-    width: '100%',
-    height: '100%',
-  },
-  boardCompact: {
-    minHeight: 360,
-  },
-  gridLayer: {
-    ...StyleSheet.absoluteFillObject,
-  },
-  gridVertical: {
-    position: 'absolute',
-    top: 0,
-    bottom: 0,
-    borderLeftWidth: 1,
-    opacity: 0.35,
-  },
-  gridHorizontal: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    borderTopWidth: 1,
-    opacity: 0.35,
-  },
-  labelOverlay: {
-    position: 'absolute',
-    left: 12,
-    top: 12,
-    zIndex: 1,
-    maxWidth: '75%',
-  },
-  overlayTitle: {
-    fontSize: 14,
-    fontWeight: '700',
-  },
-  overlaySubtitle: {
-    fontSize: 11,
-    marginTop: 2,
-  },
-  markerLayer: {
-    ...StyleSheet.absoluteFillObject,
-    zIndex: 2,
-  },
-  markerWrap: {
-    position: 'absolute',
-  },
-  marker: {
-    alignItems: 'center',
-  },
-  markerSelected: {
-    zIndex: 3,
-  },
-  pinWrapper: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 28,
-    height: 28,
-    marginBottom: 4,
-  },
-  bubble: {
-    minWidth: 88,
-    maxWidth: 136,
-    borderWidth: 1,
-    borderRadius: 12,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOpacity: 0.18,
-    shadowRadius: 6,
-    shadowOffset: { width: 0, height: 4 },
-    elevation: 4,
-  },
-  bubbleTitle: {
-    fontSize: 13,
-    fontWeight: '700',
-    textAlign: 'center',
-  },
-  bubbleSubtitle: {
-    fontSize: 10,
-    marginTop: 2,
-    textAlign: 'center',
-  },
-  selectedRing: {
-    position: 'absolute',
-    width: 30,
-    height: 30,
-    borderRadius: 15,
-    borderWidth: 2,
-    opacity: 0.6,
-  },
-  loadingLayer: {
-    flex: 1,
-    minHeight: 260,
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 8,
-  },
-  loadingText: {
-    fontSize: 13,
-  },
-  pinLayer: {
-    ...StyleSheet.absoluteFillObject,
-    zIndex: 3,
-  },
-  legendRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: 12,
-  },
-  legendItem: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-  },
-  legendDot: {
-    width: 10,
-    height: 10,
-    borderRadius: 999,
-  },
-  legendText: {
-    fontSize: 12,
-  },
+  /** 外枠コンテナ */
+  container: { borderWidth: 1, borderRadius: 14, padding: 12, gap: 10 },
+  /** ヘッダー行 */
+  headerRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  /** セクションタイトル */
+  title: { fontSize: 16, fontWeight: '700' },
+  /** 説明テキスト */
+  description: { fontSize: 13, lineHeight: 19 },
+  /** マップ表示エリア */
+  mapContainer: { borderRadius: 12, overflow: 'hidden', minHeight: 300 },
+  /** WebView スタイル */
+  webView: { flex: 1, backgroundColor: 'transparent' },
+  /** フォールバック表示 */
+  fallback: { borderWidth: 1, borderRadius: 12, alignItems: 'center', justifyContent: 'center', gap: 8 },
+  /** フォールバックテキスト */
+  fallbackText: { fontSize: 13 },
+  /** 凡例行 */
+  legendRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 12 },
+  /** 凡例アイテム */
+  legendItem: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  /** 凡例ドット */
+  legendDot: { width: 10, height: 10, borderRadius: 999 },
+  /** 凡例テキスト */
+  legendText: { fontSize: 12 },
 });
 
 export default ShiftLocationMap;

--- a/src/features/item6/components/leafletMapHtml.js
+++ b/src/features/item6/components/leafletMapHtml.js
@@ -1,0 +1,331 @@
+/**
+ * Leaflet CRS.Simple を利用したキャンパスマップの HTML テンプレート
+ * Native (iOS/Android) では WebView 内でこの HTML を描画する。
+ *
+ * @param {Object} params - HTML生成パラメータ
+ * @param {string} params.mapImageBase64 - マップ画像の Base64 データURI
+ * @param {number} params.imgWidth - マップ画像の幅（ピクセル）
+ * @param {number} params.imgHeight - マップ画像の高さ（ピクセル）
+ * @returns {string} Leaflet マップを含む完全な HTML 文字列
+ */
+export const buildLeafletHtml = ({ mapImageBase64, imgWidth, imgHeight }) => {
+  return `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { width: 100%; height: 100%; overflow: hidden; }
+    #map { width: 100%; height: 100%; background: transparent; }
+
+    /* ドロップピン型マーカー */
+    .marker-pin {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      filter: drop-shadow(0 2px 4px rgba(0,0,0,0.35));
+      cursor: pointer;
+    }
+    .marker-pin svg {
+      width: 32px;
+      height: 40px;
+      transition: transform 0.15s ease;
+    }
+    .marker-pin:hover svg {
+      transform: scale(1.15);
+    }
+    .marker-pin .pin-label {
+      margin-top: 2px;
+      background: rgba(0,0,0,0.78);
+      color: #fff;
+      padding: 3px 8px;
+      border-radius: 4px;
+      font-size: 11px;
+      font-weight: 700;
+      white-space: nowrap;
+      max-width: 120px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      text-align: center;
+    }
+    .marker-pin.selected .pin-label {
+      background: #E53935;
+    }
+    .marker-pin.highlighted .pin-label {
+      background: #43A047;
+    }
+    .marker-pin.draft .pin-label {
+      background: #FF9800;
+    }
+    /* 選択時のバウンスアニメーション */
+    .marker-pin.selected svg {
+      animation: pin-bounce 0.4s ease;
+    }
+    @keyframes pin-bounce {
+      0% { transform: translateY(0); }
+      30% { transform: translateY(-8px); }
+      60% { transform: translateY(0); }
+      80% { transform: translateY(-3px); }
+      100% { transform: translateY(0); }
+    }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script>
+    (function() {
+      var IMG_WIDTH = ${imgWidth};
+      var IMG_HEIGHT = ${imgHeight};
+      var bounds = [[0, 0], [IMG_HEIGHT, IMG_WIDTH]];
+
+      var map = L.map('map', {
+        crs: L.CRS.Simple,
+        minZoom: -2,
+        maxZoom: 3,
+        zoomSnap: 0.5,
+        maxBounds: [[-50, -50], [IMG_HEIGHT + 50, IMG_WIDTH + 50]],
+        maxBoundsViscosity: 0.8
+      });
+
+      L.imageOverlay('${mapImageBase64}', bounds).addTo(map);
+      map.fitBounds(bounds);
+
+      /** @type {Object<string, L.Marker>} マーカーIDをキーとするマーカーマップ */
+      var markers = {};
+      /** @type {L.Marker|null} ドラフト（新規登録用）マーカー */
+      var draftMarker = null;
+      /** @type {string} 現在の操作モード（'pin' or 'move'） */
+      var interactionMode = 'pin';
+      /** @type {boolean} 編集モードが有効か */
+      var canEdit = false;
+
+      /**
+       * 緯度経度をLeaflet CRS.Simple座標に変換する
+       * @param {number} lat - 緯度
+       * @param {number} lng - 経度
+       * @param {Object} campusBounds - キャンパス座標範囲
+       * @returns {Array<number>} [y, x] 形式のLeaflet座標
+       */
+      function geoToPixel(lat, lng, campusBounds) {
+        var xRatio = (lng - campusBounds.longitudeMin) / (campusBounds.longitudeMax - campusBounds.longitudeMin);
+        var yRatio = 1 - (lat - campusBounds.latitudeMin) / (campusBounds.latitudeMax - campusBounds.latitudeMin);
+        return [yRatio * IMG_HEIGHT, xRatio * IMG_WIDTH];
+      }
+
+      /**
+       * Leaflet CRS.Simple座標を緯度経度に変換する
+       * @param {number} y - Leaflet Y座標
+       * @param {number} x - Leaflet X座標
+       * @param {Object} campusBounds - キャンパス座標範囲
+       * @returns {Object} { latitude, longitude }
+       */
+      function pixelToGeo(y, x, campusBounds) {
+        var xRatio = x / IMG_WIDTH;
+        var yRatio = y / IMG_HEIGHT;
+        return {
+          latitude: campusBounds.latitudeMin + (1 - yRatio) * (campusBounds.latitudeMax - campusBounds.latitudeMin),
+          longitude: campusBounds.longitudeMin + xRatio * (campusBounds.longitudeMax - campusBounds.longitudeMin)
+        };
+      }
+
+      /**
+       * SVG ドロップピン型の DivIcon を生成する
+       * 状態に応じてピンの色を変更し、場所名ラベルを表示する
+       * @param {string} name - 表示名
+       * @param {boolean} isSelected - 選択状態か（赤）
+       * @param {boolean} isHighlighted - ハイライト状態か（緑）
+       * @param {boolean} isDraft - ドラフトか（オレンジ）
+       * @returns {L.DivIcon}
+       */
+      function createIcon(name, isSelected, isHighlighted, isDraft) {
+        var color = isDraft ? '#FF9800'
+          : isSelected ? '#E53935'
+          : isHighlighted ? '#43A047'
+          : '#1976D2';
+        var cls = 'marker-pin';
+        if (isDraft) cls += ' draft';
+        else if (isSelected) cls += ' selected';
+        else if (isHighlighted) cls += ' highlighted';
+        var html = '<div class="' + cls + '">'
+          + '<svg viewBox="0 0 24 36" xmlns="http://www.w3.org/2000/svg">'
+          + '<path d="M12 0C5.4 0 0 5.4 0 12c0 9 12 24 12 24s12-15 12-24C24 5.4 18.6 0 12 0z" fill="' + color + '"/>'
+          + '<circle cx="12" cy="12" r="5" fill="#fff"/>'
+          + '</svg>'
+          + '<span class="pin-label">' + name + '</span>'
+          + '</div>';
+        return L.divIcon({
+          className: '',
+          html: html,
+          iconSize: [32, 52],
+          iconAnchor: [16, 44]
+        });
+      }
+
+      /**
+       * React Native からのメッセージを処理する
+       * @param {MessageEvent} event - postMessage イベント
+       */
+      function handleMessage(event) {
+        var data;
+        try {
+          data = JSON.parse(event.data);
+        } catch (e) {
+          return;
+        }
+
+        if (data.type === 'updateMarkers') {
+          updateMarkers(data.payload);
+        } else if (data.type === 'updateMode') {
+          interactionMode = data.payload.interactionMode || 'pin';
+          canEdit = !!data.payload.canEdit;
+          applyInteractionMode();
+        } else if (data.type === 'focusLocation') {
+          focusOnLocation(data.payload);
+        } else if (data.type === 'updateDraft') {
+          updateDraftMarker(data.payload);
+        }
+      }
+
+      /**
+       * すべてのマーカーを更新する
+       * @param {Object} payload - マーカー更新データ
+       */
+      function updateMarkers(payload) {
+        var locations = payload.locations || [];
+        var selectedId = payload.selectedLocationId || '';
+        var highlightedId = payload.highlightedLocationId || '';
+        var campusBounds = payload.campusBounds;
+
+        /* 既存マーカーを全削除 */
+        Object.keys(markers).forEach(function(id) {
+          map.removeLayer(markers[id]);
+        });
+        markers = {};
+
+        /* アクティブな場所のマーカーを追加 */
+        locations.forEach(function(loc) {
+          if (loc.is_active === false) return;
+          var pos = geoToPixel(Number(loc.latitude), Number(loc.longitude), campusBounds);
+          var isSelected = loc.id === selectedId;
+          var isHighlighted = loc.id === highlightedId;
+          var icon = createIcon(loc.name, isSelected, isHighlighted, false);
+          var m = L.marker(pos, { icon: icon, draggable: isSelected && canEdit })
+            .addTo(map);
+
+          m.on('click', function() {
+            sendToRN({ type: 'locationPress', payload: { id: loc.id } });
+          });
+
+          m.on('dragend', function(e) {
+            var latlng = e.target.getLatLng();
+            var geo = pixelToGeo(latlng.lat, latlng.lng, campusBounds);
+            sendToRN({ type: 'draftCoordinateChange', payload: geo });
+          });
+
+          markers[loc.id] = m;
+        });
+      }
+
+      /**
+       * ドラフトマーカーを更新・表示する
+       * @param {Object} payload - ドラフト座標データ
+       */
+      function updateDraftMarker(payload) {
+        if (!payload || !payload.coordinate || !payload.campusBounds) {
+          if (draftMarker) {
+            map.removeLayer(draftMarker);
+            draftMarker = null;
+          }
+          return;
+        }
+        var pos = geoToPixel(
+          Number(payload.coordinate.latitude),
+          Number(payload.coordinate.longitude),
+          payload.campusBounds
+        );
+        var icon = createIcon(payload.label || '選択中の位置', false, false, true);
+
+        if (draftMarker) {
+          draftMarker.setLatLng(pos);
+          draftMarker.setIcon(icon);
+        } else {
+          draftMarker = L.marker(pos, { icon: icon }).addTo(map);
+        }
+      }
+
+      /**
+       * 指定した場所にマップをパンする
+       * @param {Object} payload - フォーカス対象データ
+       */
+      function focusOnLocation(payload) {
+        if (!payload || !payload.coordinate || !payload.campusBounds) return;
+        var pos = geoToPixel(
+          Number(payload.coordinate.latitude),
+          Number(payload.coordinate.longitude),
+          payload.campusBounds
+        );
+        map.setView(pos, 1, { animate: true });
+      }
+
+      /**
+       * React Native にメッセージを送信する
+       * @param {Object} msg - 送信するメッセージオブジェクト
+       */
+      function sendToRN(msg) {
+        if (window.ReactNativeWebView) {
+          window.ReactNativeWebView.postMessage(JSON.stringify(msg));
+        } else {
+          /* Web版: カスタムイベントで通知 */
+          window.dispatchEvent(new CustomEvent('leafletMapEvent', { detail: msg }));
+        }
+      }
+
+      /**
+       * 操作モードに応じてマップのドラッグ・ズーム操作を切り替える
+       * - ピン指定モード: ドラッグ無効（タップでピンを配置可能に）、ズームは有効
+       * - 地図移動モード: ドラッグ有効（通常のマップ操作）
+       */
+      function applyInteractionMode() {
+        if (canEdit && interactionMode === 'pin') {
+          map.dragging.disable();
+          map.getContainer().style.cursor = 'crosshair';
+        } else {
+          map.dragging.enable();
+          map.getContainer().style.cursor = '';
+        }
+      }
+
+      /* 初回のモード適用 */
+      applyInteractionMode();
+
+      /* マップタップでピンを立てるイベント */
+      map.on('click', function(e) {
+        if (!canEdit || interactionMode !== 'pin') return;
+        sendToRN({ type: 'boardPress', payload: pixelToGeo(e.latlng.lat, e.latlng.lng, window._campusBounds || {}) });
+      });
+
+      /* メッセージ受信の設定 */
+      window.addEventListener('message', handleMessage);
+      document.addEventListener('message', handleMessage);
+
+      /* グローバルAPI: Web版から直接呼べるようにする */
+      window.leafletMap = {
+        updateMarkers: function(payload) { updateMarkers(payload); window._campusBounds = payload.campusBounds; },
+        updateMode: function(payload) { interactionMode = payload.interactionMode || 'pin'; canEdit = !!payload.canEdit; applyInteractionMode(); },
+        focusLocation: function(payload) { focusOnLocation(payload); },
+        updateDraft: function(payload) { updateDraftMarker(payload); },
+        getMap: function() { return map; }
+      };
+
+      /* 読み込み完了を通知 */
+      sendToRN({ type: 'mapReady' });
+    })();
+  </script>
+</body>
+</html>
+`;
+};

--- a/src/features/item6/constants.js
+++ b/src/features/item6/constants.js
@@ -17,6 +17,7 @@ export const LOCATION_ACTION_TYPES = {
   update: 'update',
   delete: 'delete',
   selfRegister: 'self_register',
+  statusChange: 'status_change',
 };
 
 export const MAP_INTERACTION_MODES = {
@@ -24,6 +25,39 @@ export const MAP_INTERACTION_MODES = {
   pin: 'pin',
 };
 
+/**
+ * 厚生部員のステータス
+ * 厚生部長が配置状況を把握するための3つの状態
+ * - stationed: 特定の場所に配置中
+ * - patrolling: 巡回中（移動中のため特定の場所に紐づかない）
+ * - away: 一時的に持ち場を離れている
+ */
+export const MEMBER_STATUS = {
+  /** 配置中: 特定の場所にいる */
+  stationed: 'stationed',
+  /** 巡回中: 複数の場所を移動中 */
+  patrolling: 'patrolling',
+  /** 離席中: 一時的に持ち場を離れている */
+  away: 'away',
+};
+
+/**
+ * ステータスの表示ラベル
+ */
+export const MEMBER_STATUS_LABELS = {
+  stationed: '配置中',
+  patrolling: '巡回中',
+  away: '離席中',
+};
+
+/**
+ * キャンパスマップの中心座標とズーム範囲
+ * ピンの位置がずれる場合は以下の手順でキャリブレーションする:
+ * 1. Google マップで map.png の四隅にある建物の緯度経度を調べる
+ * 2. latitude / longitude を画像中心の座標に合わせる
+ * 3. latitudeDelta / longitudeDelta を画像の南北・東西の範囲に合わせる
+ * 例: 画像の北端が 34.654, 南端が 34.649 なら latitudeDelta = 0.005
+ */
 export const DEFAULT_MAP_REGION = {
   latitude: 34.651251510533875,
   longitude: 135.58943350065954,
@@ -31,6 +65,10 @@ export const DEFAULT_MAP_REGION = {
   longitudeDelta: 0.0045,
 };
 
+/**
+ * キャンパス画像の座標範囲（DEFAULT_MAP_REGION から自動計算）
+ * この範囲が画像ピクセル [0,0]〜[900,1191] にマッピングされる
+ */
 export const CAMPUS_BOUNDS = {
   latitudeMin: DEFAULT_MAP_REGION.latitude - DEFAULT_MAP_REGION.latitudeDelta / 2,
   latitudeMax: DEFAULT_MAP_REGION.latitude + DEFAULT_MAP_REGION.latitudeDelta / 2,

--- a/src/features/item6/screens/KoseibuLocationScreen.jsx
+++ b/src/features/item6/screens/KoseibuLocationScreen.jsx
@@ -26,6 +26,8 @@ import { hasRole, isAdmin } from '../../../services/supabase/permissionService';
 import {
   DEFAULT_MAP_REGION,
   MAP_INTERACTION_MODES,
+  MEMBER_STATUS,
+  MEMBER_STATUS_LABELS,
   ROLE_NAMES,
   SCREEN_NAME,
 } from '../constants.js';
@@ -36,6 +38,7 @@ import {
   registerKoseibuShiftCurrentLocation,
   selectKoseibuShiftOverview,
   updateKoseibuShiftLocation,
+  updateKoseibuShiftMemberStatus,
 } from '../services/shiftLocationService.js';
 
 const MOBILE_BREAKPOINT = 768;
@@ -154,6 +157,8 @@ const Item6LocationScreen = ({ navigation }) => {
   const [currentLocations, setCurrentLocations] = useState([]);
   const [selectedCurrentLocationId, setSelectedCurrentLocationId] = useState('');
   const [currentLocationDraftId, setCurrentLocationDraftId] = useState('');
+  /** @type {string} 現在選択中のステータス */
+  const [statusDraft, setStatusDraft] = useState(MEMBER_STATUS.stationed);
   const [currentLocationSearchQuery, setCurrentLocationSearchQuery] = useState('');
   const [currentLocationFilterId, setCurrentLocationFilterId] = useState('');
   const [activeTab, setActiveTab] = useState(ITEM6_TABS.location);
@@ -214,6 +219,13 @@ const Item6LocationScreen = ({ navigation }) => {
     }
     return currentLocations.find((record) => record.user_id === user.id) ?? null;
   }, [currentLocations, user?.id]);
+
+  /** myCurrentLocationのステータスでstatusDraftを初期化する */
+  useEffect(() => {
+    if (myCurrentLocation?.status) {
+      setStatusDraft(myCurrentLocation.status);
+    }
+  }, [myCurrentLocation?.status]);
 
   const selectedCurrentLocation = useMemo(() => {
     return locations.find((location) => location.id === selectedCurrentLocationId) ?? null;
@@ -308,7 +320,7 @@ const Item6LocationScreen = ({ navigation }) => {
         available: canView,
       },
     ];
-  }, [canManageLocations, canRegisterLocations, canRegisterSelf, canView]);
+  }, [canRegisterLocations, canRegisterSelf, canView]);
 
   const visibleTabItems = useMemo(() => tabItems.filter((item) => item.available), [tabItems]);
 
@@ -379,8 +391,16 @@ const Item6LocationScreen = ({ navigation }) => {
     }
 
     const supabase = getSupabaseClient();
-    const reload = () => {
-      refreshOverview();
+
+    /** デバウンス用タイマー。連続的な変更通知を500msにまとめる */
+    let debounceTimer = null;
+    const debouncedReload = () => {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+      }
+      debounceTimer = setTimeout(() => {
+        refreshOverview();
+      }, 500);
     };
 
     const channel = supabase
@@ -388,16 +408,19 @@ const Item6LocationScreen = ({ navigation }) => {
       .on(
         'postgres_changes',
         { event: '*', schema: 'public', table: 'koseibu_shift_locations' },
-        reload
+        debouncedReload
       )
       .on(
         'postgres_changes',
         { event: '*', schema: 'public', table: 'koseibu_shift_current_locations' },
-        reload
+        debouncedReload
       )
       .subscribe();
 
     return () => {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+      }
       supabase.removeChannel(channel);
     };
   }, [authLoading, canView, refreshOverview]);
@@ -470,8 +493,13 @@ const Item6LocationScreen = ({ navigation }) => {
     }
   };
 
+  /**
+   * マップタップ時のピン配置ハンドラ
+   * 厚生部員（登録権限あり）がマップをタップして座標を指定する
+   * @param {Object} coordinate - タップされた座標 { latitude, longitude }
+   */
   const handleMapBoardPress = (coordinate) => {
-    if (!canManageLocations) {
+    if (!canRegisterLocations) {
       return;
     }
 
@@ -567,13 +595,18 @@ const Item6LocationScreen = ({ navigation }) => {
     }
   };
 
+  /**
+   * 現在地・ステータスを登録するハンドラ
+   * ステータスに応じて適切なサービス関数を呼び出す
+   */
   const handleRegisterCurrentLocation = async () => {
     if (!canRegisterSelf || !user?.id) {
       return;
     }
 
-    if (!currentLocationDraftId) {
-      setErrorMessage('現在地に登録する場所を選択してください');
+    /** 配置中の場合は場所の選択が必須 */
+    if (statusDraft === MEMBER_STATUS.stationed && !currentLocationDraftId) {
+      setErrorMessage('配置中は場所を選択してください');
       return;
     }
 
@@ -581,15 +614,20 @@ const Item6LocationScreen = ({ navigation }) => {
     setErrorMessage('');
 
     try {
-      const result = await registerKoseibuShiftCurrentLocation(user.id, currentLocationDraftId, user.id);
+      const result = await updateKoseibuShiftMemberStatus(
+        user.id,
+        statusDraft,
+        statusDraft === MEMBER_STATUS.stationed ? currentLocationDraftId : null,
+        user.id
+      );
       if (result.error) {
-        setErrorMessage(result.error.message || '現在地登録に失敗しました');
+        setErrorMessage(result.error.message || 'ステータス登録に失敗しました');
         return;
       }
 
       await refreshOverview();
     } catch (error) {
-      setErrorMessage(error.message || '現在地登録に失敗しました');
+      setErrorMessage(error.message || 'ステータス登録に失敗しました');
     } finally {
       setSaving(false);
     }
@@ -628,7 +666,9 @@ const Item6LocationScreen = ({ navigation }) => {
               {record.user_name}
               {isMine ? '（自分）' : ''}
             </Text>
-            <Text style={[styles.rowMeta, { color: theme.textSecondary }]}>{record.location_name_snapshot}</Text>
+            <Text style={[styles.rowMeta, { color: theme.textSecondary }]}>
+              {record.status === 'patrolling' ? '🔄 巡回中' : record.status === 'away' ? '⏸ 離席中' : record.location_name_snapshot || '未設定'}
+            </Text>
             <Text style={[styles.rowMeta, { color: theme.textSecondary }]}>{formatDateTime(record.updated_at)}</Text>
           </View>
           <Badge label={isMine ? '自分' : '登録済み'} color={isMine ? theme.primary : theme.success} backgroundColor={isMine ? `${theme.primary}18` : `${theme.success}20`} />
@@ -666,6 +706,17 @@ const Item6LocationScreen = ({ navigation }) => {
       <ThemedHeader title={SCREEN_NAME} navigation={navigation} />
 
       <ScrollView contentContainerStyle={styles.scrollContent}>
+        {/* エラーバナーはスクロール最上部に表示して見逃しを防ぐ */}
+        {errorMessage ? (
+          <View style={[styles.errorBanner, { borderColor: theme.error, backgroundColor: `${theme.error}12` }]}>
+            <MaterialCommunityIcons name="alert-circle-outline" size={20} color={theme.error} />
+            <Text style={[styles.errorBannerText, { color: theme.error }]}>{errorMessage}</Text>
+            <TouchableOpacity onPress={() => setErrorMessage('')} activeOpacity={0.7}>
+              <MaterialCommunityIcons name="close" size={18} color={theme.error} />
+            </TouchableOpacity>
+          </View>
+        ) : null}
+
         <View style={styles.pageHeader}>
           <View style={styles.pageHeaderRow}>
             <MaterialCommunityIcons name="map-marker-radius" size={24} color={theme.primary} />
@@ -727,7 +778,11 @@ const Item6LocationScreen = ({ navigation }) => {
                         opacity: isDisabled ? 0.45 : 1,
                       },
                     ]}
-                    onPress={() => !isDisabled && setActiveTab(tab.key)}
+                    onPress={() => {
+                      if (isDisabled) return;
+                      setActiveTab(tab.key);
+                      setErrorMessage('');
+                    }}
                     disabled={isDisabled}
                     activeOpacity={0.8}
                   >
@@ -928,72 +983,116 @@ const Item6LocationScreen = ({ navigation }) => {
               <View style={styles.tabPanel}>
                 {canRegisterSelf ? (
                   <SectionCard title="自分の場所登録" subtitle="一覧から選択して登録" theme={theme}>
-                    <View style={styles.choiceGroup}>
-                      {currentLocationOptions.length === 0 ? (
-                        <View style={styles.emptyState}>
-                          <MaterialCommunityIcons name="map-marker-off" size={28} color={theme.textSecondary} />
-                          <Text style={[styles.emptyStateText, { color: theme.textSecondary }]}>
-                            選択できる場所がありません
-                          </Text>
-                        </View>
-                      ) : (
-                        currentLocationOptions.map((option) => {
-                          const selected = currentLocationDraftId === option.value;
-
-                          return (
-                            <TouchableOpacity
-                              key={option.value}
-                              style={[
-                                styles.choiceCard,
-                                {
-                                  backgroundColor: selected ? theme.primary : theme.background,
-                                  borderColor: selected ? theme.primary : theme.border,
-                                },
-                              ]}
-                              onPress={() => setCurrentLocationDraftId(option.value)}
-                              activeOpacity={0.8}
-                            >
-                              <View style={styles.choiceTextWrap}>
-                                <Text style={[styles.choiceTitle, { color: selected ? '#fff' : theme.text }]}>
-                                  {option.label}
-                                </Text>
-                                <Text
-                                  style={[
-                                    styles.choiceSubtitle,
-                                    { color: selected ? 'rgba(255,255,255,0.82)' : theme.textSecondary },
-                                  ]}
-                                >
-                                  タップして選択
-                                </Text>
-                              </View>
-                              {selected ? <MaterialCommunityIcons name="check" size={18} color="#fff" /> : null}
-                            </TouchableOpacity>
-                          );
-                        })
-                      )}
+                    {/* ステータス切替ボタン */}
+                    <View style={styles.statusRow}>
+                      {Object.entries(MEMBER_STATUS_LABELS).map(([key, label]) => {
+                        const isActive = statusDraft === key;
+                        return (
+                          <TouchableOpacity
+                            key={key}
+                            style={[
+                              styles.statusButton,
+                              {
+                                backgroundColor: isActive ? theme.primary : theme.background,
+                                borderColor: isActive ? theme.primary : theme.border,
+                              },
+                            ]}
+                            onPress={() => setStatusDraft(key)}
+                            activeOpacity={0.8}
+                          >
+                            <Text style={[styles.statusButtonText, { color: isActive ? '#fff' : theme.text }]}>
+                              {label}
+                            </Text>
+                          </TouchableOpacity>
+                        );
+                      })}
                     </View>
 
-                    <ShiftLocationMap
-                      theme={theme}
-                      compact={isCompact}
-                      height={isCompact ? 280 : 340}
-                      locations={activeLocations}
-                      interactionMode={MAP_INTERACTION_MODES.move}
-                      selectedLocationId={currentLocationDraftId}
-                      highlightedLocationId={currentLocationDraftId}
-                      focusLocationId={currentLocationDraftId}
-                      canEdit={false}
-                    />
+                    {statusDraft === MEMBER_STATUS.stationed ? (
+                      <>
+                        <View style={styles.choiceGroup}>
+                          {currentLocationOptions.length === 0 ? (
+                            <View style={styles.emptyState}>
+                              <MaterialCommunityIcons name="map-marker-off" size={28} color={theme.textSecondary} />
+                              <Text style={[styles.emptyStateText, { color: theme.textSecondary }]}>
+                                選択できる場所がありません
+                              </Text>
+                            </View>
+                          ) : (
+                            currentLocationOptions.map((option) => {
+                              const selected = currentLocationDraftId === option.value;
 
-                    <Text style={[styles.helperText, { color: theme.textSecondary }]}>
-                      選択した場所はマップ上でも強調表示されます。
-                    </Text>
+                              return (
+                                <TouchableOpacity
+                                  key={option.value}
+                                  style={[
+                                    styles.choiceCard,
+                                    {
+                                      backgroundColor: selected ? theme.primary : theme.background,
+                                      borderColor: selected ? theme.primary : theme.border,
+                                    },
+                                  ]}
+                                  onPress={() => setCurrentLocationDraftId(option.value)}
+                                  activeOpacity={0.8}
+                                >
+                                  <View style={styles.choiceTextWrap}>
+                                    <Text style={[styles.choiceTitle, { color: selected ? '#fff' : theme.text }]}>
+                                      {option.label}
+                                    </Text>
+                                    <Text
+                                      style={[
+                                        styles.choiceSubtitle,
+                                        { color: selected ? 'rgba(255,255,255,0.82)' : theme.textSecondary },
+                                      ]}
+                                    >
+                                      タップして選択
+                                    </Text>
+                                  </View>
+                                  {selected ? <MaterialCommunityIcons name="check" size={18} color="#fff" /> : null}
+                                </TouchableOpacity>
+                              );
+                            })
+                          )}
+                        </View>
+
+                        <ShiftLocationMap
+                          theme={theme}
+                          compact={isCompact}
+                          height={isCompact ? 280 : 340}
+                          locations={activeLocations}
+                          interactionMode={MAP_INTERACTION_MODES.move}
+                          selectedLocationId={currentLocationDraftId}
+                          highlightedLocationId={currentLocationDraftId}
+                          focusLocationId={currentLocationDraftId}
+                          canEdit={false}
+                        />
+
+                        <Text style={[styles.helperText, { color: theme.textSecondary }]}>
+                          選択した場所はマップ上でも強調表示されます。
+                        </Text>
+                      </>
+                    ) : null}
+
+                    {statusDraft !== MEMBER_STATUS.stationed ? (
+                      <View style={styles.emptyState}>
+                        <MaterialCommunityIcons
+                          name={statusDraft === MEMBER_STATUS.patrolling ? 'walk' : 'account-clock'}
+                          size={28}
+                          color={theme.textSecondary}
+                        />
+                        <Text style={[styles.emptyStateText, { color: theme.textSecondary }]}>
+                          {statusDraft === MEMBER_STATUS.patrolling
+                            ? '巡回中として登録されます。特定の場所には紐づきません。'
+                            : '離席中として登録されます。一時的に持ち場を離れていることが記録されます。'}
+                        </Text>
+                      </View>
+                    ) : null}
 
                     <ActionButton
-                      label={saving ? '登録中...' : '現在地を登録'}
+                      label={saving ? '登録中...' : `${MEMBER_STATUS_LABELS[statusDraft]}を登録`}
                       onPress={handleRegisterCurrentLocation}
                       theme={theme}
-                      disabled={saving || currentLocationOptions.length === 0}
+                      disabled={saving || (statusDraft === MEMBER_STATUS.stationed && currentLocationOptions.length === 0)}
                     />
                   </SectionCard>
                 ) : (
@@ -1062,12 +1161,6 @@ const Item6LocationScreen = ({ navigation }) => {
           </>
         )}
 
-        {errorMessage ? (
-          <View style={[styles.errorBanner, { borderColor: theme.error, backgroundColor: `${theme.error}12` }]}>
-            <MaterialCommunityIcons name="alert-circle-outline" size={20} color={theme.error} />
-            <Text style={[styles.errorBannerText, { color: theme.error }]}>{errorMessage}</Text>
-          </View>
-        ) : null}
       </ScrollView>
     </SafeAreaView>
   );
@@ -1374,6 +1467,29 @@ const styles = StyleSheet.create({
     paddingVertical: 7,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  /** ステータス切替行 */
+  statusRow: {
+    flexDirection: 'row',
+    gap: 8,
+    flexWrap: 'wrap',
+  },
+  /** ステータスボタン */
+  statusButton: {
+    flex: 1,
+    minWidth: 80,
+    minHeight: 40,
+    borderWidth: 1,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  /** ステータスボタンテキスト */
+  statusButtonText: {
+    fontSize: 14,
+    fontWeight: '700',
   },
   errorBanner: {
     borderWidth: 1,

--- a/src/features/item6/services/shiftLocationService.js
+++ b/src/features/item6/services/shiftLocationService.js
@@ -4,7 +4,7 @@
 
 import { getSupabaseClient } from '../../../services/supabase/client.js';
 import { getUserProfilesByIds } from '../../../shared/services/notificationService.js';
-import { LOCATION_ACTION_TYPES } from '../constants.js';
+import { LOCATION_ACTION_TYPES, MEMBER_STATUS } from '../constants.js';
 
 const uniqueStrings = (values = []) => {
   return Array.from(
@@ -66,7 +66,6 @@ const insertShiftLocationLog = async ({
       action_type: actionType,
       operated_by: operatedBy,
       memo,
-      created_at: new Date().toISOString(),
     })
     .select()
     .single();
@@ -185,7 +184,7 @@ export const selectKoseibuShiftOverview = async ({ includeLogs = true } = {}) =>
     if (profileIds.length > 0) {
       const { profiles, error: profileError } = await getUserProfilesByIds(profileIds);
       if (profileError) {
-        console.warn('厚生部場所管理: プロフィール取得に失敗しました', profileError);
+        /* プロフィール取得失敗は名前未表示になるが、操作には影響しない */
       } else {
         profileMap = buildProfileMap(profiles);
       }
@@ -207,10 +206,14 @@ export const selectKoseibuShiftOverview = async ({ includeLogs = true } = {}) =>
   }
 };
 
+/**
+ * 厚生部シフト場所を新規登録する
+ * @param {Object} payload - 登録データ
+ * @returns {Promise<{location: Object|null, log: Object|null, error: Object|null}>}
+ */
 export const insertKoseibuShiftLocation = async (payload) => {
   try {
     const supabase = getSupabaseClient();
-    const timestamp = new Date().toISOString();
     const { data, error } = await supabase
       .from('koseibu_shift_locations')
       .insert({
@@ -221,8 +224,6 @@ export const insertKoseibuShiftLocation = async (payload) => {
         display_order: payload.displayOrder ?? 0,
         is_active: true,
         created_by: payload.createdBy,
-        created_at: timestamp,
-        updated_at: timestamp,
       })
       .select()
       .single();
@@ -231,26 +232,30 @@ export const insertKoseibuShiftLocation = async (payload) => {
       return { location: null, log: null, error };
     }
 
-    const { log, error: logError } = await insertShiftLocationLog({
+    const { log } = await insertShiftLocationLog({
       locationId: data.id,
       locationNameSnapshot: data.name,
       latitudeSnapshot: data.latitude,
       longitudeSnapshot: data.longitude,
       actionType: LOCATION_ACTION_TYPES.create,
       operatedBy: payload.createdBy,
-      memo: payload.description ?? null,
+      memo: `場所「${data.name}」を新規登録`,
     });
 
-    if (logError) {
-      return { location: data, log: null, error: logError };
-    }
-
-    return { location: data, log, error: null };
+    /* ログ書き込み失敗は警告に留め、操作自体は成功として返す */
+    return { location: data, log: log ?? null, error: null };
   } catch (error) {
     return { location: null, log: null, error };
   }
 };
 
+/**
+ * 厚生部シフト場所を更新する
+ * @param {string} locationId - 更新対象の場所ID
+ * @param {Object} payload - 更新データ
+ * @param {string} operatedBy - 操作者のユーザーID
+ * @returns {Promise<{location: Object|null, log: Object|null, error: Object|null}>}
+ */
 export const updateKoseibuShiftLocation = async (locationId, payload, operatedBy) => {
   try {
     const supabase = getSupabaseClient();
@@ -263,7 +268,6 @@ export const updateKoseibuShiftLocation = async (locationId, payload, operatedBy
         ...(payload.description !== undefined ? { description: payload.description } : {}),
         ...(payload.displayOrder !== undefined ? { display_order: payload.displayOrder } : {}),
         ...(payload.isActive !== undefined ? { is_active: payload.isActive } : {}),
-        updated_at: new Date().toISOString(),
       })
       .eq('id', locationId)
       .select()
@@ -272,6 +276,10 @@ export const updateKoseibuShiftLocation = async (locationId, payload, operatedBy
     if (error) {
       return { location: null, log: null, error };
     }
+
+    /** 更新された項目を記録用メモに含める */
+    const changedFields = Object.keys(payload).filter((key) => payload[key] !== undefined);
+    const updateMemo = `更新項目: ${changedFields.join(', ')}`;
 
     const { log, error: logError } = await insertShiftLocationLog({
       locationId: data.id,
@@ -280,28 +288,29 @@ export const updateKoseibuShiftLocation = async (locationId, payload, operatedBy
       longitudeSnapshot: data.longitude,
       actionType: LOCATION_ACTION_TYPES.update,
       operatedBy,
-      memo: payload.description ?? null,
+      memo: updateMemo,
     });
 
-    if (logError) {
-      return { location: data, log: null, error: logError };
-    }
-
-    return { location: data, log, error: null };
+    /* ログ書き込み失敗は警告に留め、操作自体は成功として返す */
+    return { location: data, log: log ?? null, error: null };
   } catch (error) {
     return { location: null, log: null, error };
   }
 };
 
+/**
+ * 厚生部シフト場所を論理削除する（is_active = false）
+ * 該当場所を現在地として登録しているレコードもクリアする
+ * @param {string} locationId - 削除対象の場所ID
+ * @param {string} operatedBy - 操作者のユーザーID
+ * @returns {Promise<{location: Object|null, log: Object|null, error: Object|null}>}
+ */
 export const deleteKoseibuShiftLocation = async (locationId, operatedBy) => {
   try {
     const supabase = getSupabaseClient();
     const { data, error } = await supabase
       .from('koseibu_shift_locations')
-      .update({
-        is_active: false,
-        updated_at: new Date().toISOString(),
-      })
+      .update({ is_active: false })
       .eq('id', locationId)
       .select()
       .single();
@@ -310,7 +319,13 @@ export const deleteKoseibuShiftLocation = async (locationId, operatedBy) => {
       return { location: null, log: null, error };
     }
 
-    const { log, error: logError } = await insertShiftLocationLog({
+    /* 削除された場所を現在地として登録しているレコードをクリアする */
+    await supabase
+      .from('koseibu_shift_current_locations')
+      .delete()
+      .eq('location_id', locationId);
+
+    const { log } = await insertShiftLocationLog({
       locationId: data.id,
       locationNameSnapshot: data.name,
       latitudeSnapshot: data.latitude,
@@ -320,16 +335,20 @@ export const deleteKoseibuShiftLocation = async (locationId, operatedBy) => {
       memo: '場所マスタを論理削除',
     });
 
-    if (logError) {
-      return { location: data, log: null, error: logError };
-    }
-
-    return { location: data, log, error: null };
+    /* ログ書き込み失敗は警告に留め、操作自体は成功として返す */
+    return { location: data, log: log ?? null, error: null };
   } catch (error) {
     return { location: null, log: null, error };
   }
 };
 
+/**
+ * 厚生部員の現在地を登録する（upsert方式）
+ * @param {string} userId - 対象ユーザーID
+ * @param {string} locationId - 登録する場所ID
+ * @param {string} operatedBy - 操作者のユーザーID
+ * @returns {Promise<{currentLocation: Object|null, log: Object|null, error: Object|null}>}
+ */
 export const registerKoseibuShiftCurrentLocation = async (userId, locationId, operatedBy) => {
   try {
     const supabase = getSupabaseClient();
@@ -344,18 +363,17 @@ export const registerKoseibuShiftCurrentLocation = async (userId, locationId, op
       return { currentLocation: null, log: null, error: locationError };
     }
 
-    const timestamp = new Date().toISOString();
     const { data, error } = await supabase
       .from('koseibu_shift_current_locations')
       .upsert(
         {
           user_id: userId,
+          status: 'stationed',
           location_id: location.id,
           location_name_snapshot: location.name,
           latitude_snapshot: location.latitude,
           longitude_snapshot: location.longitude,
           updated_by: operatedBy,
-          updated_at: timestamp,
         },
         { onConflict: 'user_id' }
       )
@@ -366,7 +384,7 @@ export const registerKoseibuShiftCurrentLocation = async (userId, locationId, op
       return { currentLocation: null, log: null, error };
     }
 
-    const { log, error: logError } = await insertShiftLocationLog({
+    const { log } = await insertShiftLocationLog({
       userId,
       locationId: location.id,
       locationNameSnapshot: location.name,
@@ -374,14 +392,92 @@ export const registerKoseibuShiftCurrentLocation = async (userId, locationId, op
       longitudeSnapshot: location.longitude,
       actionType: LOCATION_ACTION_TYPES.selfRegister,
       operatedBy,
-      memo: '現在地を登録',
+      memo: `現在地を「${location.name}」に登録`,
     });
 
-    if (logError) {
-      return { currentLocation: data, log: null, error: logError };
+    /* ログ書き込み失敗は警告に留め、操作自体は成功として返す */
+    return { currentLocation: data, log: log ?? null, error: null };
+  } catch (error) {
+    return { currentLocation: null, log: null, error };
+  }
+};
+
+/**
+ * 厚生部員のステータスを変更する
+ * - stationed（配置中）: 場所IDが必須。現在地として登録する
+ * - patrolling（巡回中）: 場所IDは不要。巡回中として記録する
+ * - away（離席中）: 場所IDは不要。離席中として記録する
+ *
+ * @param {string} userId - 対象ユーザーID
+ * @param {string} status - ステータス ('stationed' | 'patrolling' | 'away')
+ * @param {string|null} locationId - 場所ID（stationedの場合のみ必須）
+ * @param {string} operatedBy - 操作者のユーザーID
+ * @returns {Promise<{currentLocation: Object|null, log: Object|null, error: Object|null}>}
+ */
+export const updateKoseibuShiftMemberStatus = async (userId, status, locationId, operatedBy) => {
+  try {
+    const supabase = getSupabaseClient();
+
+    /** 配置中の場合は場所情報を取得して検証する */
+    let location = null;
+    if (status === MEMBER_STATUS.stationed) {
+      if (!locationId) {
+        return { currentLocation: null, log: null, error: { message: '配置中は場所を選択してください' } };
+      }
+      const { data: locationData, error: locationError } = await supabase
+        .from('koseibu_shift_locations')
+        .select('*')
+        .eq('id', locationId)
+        .eq('is_active', true)
+        .single();
+
+      if (locationError) {
+        return { currentLocation: null, log: null, error: locationError };
+      }
+      location = locationData;
     }
 
-    return { currentLocation: data, log, error: null };
+    /** upsert用のデータを構築（巡回中・離席中は場所情報をNULLにする） */
+    const upsertData = {
+      user_id: userId,
+      status,
+      location_id: location?.id ?? null,
+      location_name_snapshot: location?.name ?? null,
+      latitude_snapshot: location?.latitude ?? null,
+      longitude_snapshot: location?.longitude ?? null,
+      updated_by: operatedBy,
+    };
+
+    const { data, error } = await supabase
+      .from('koseibu_shift_current_locations')
+      .upsert(upsertData, { onConflict: 'user_id' })
+      .select()
+      .single();
+
+    if (error) {
+      return { currentLocation: null, log: null, error };
+    }
+
+    /** ステータスに応じたログメモを生成する */
+    const statusLabels = { stationed: '配置中', patrolling: '巡回中', away: '離席中' };
+    const statusLabel = statusLabels[status] || status;
+    const memo = location
+      ? `ステータスを「${statusLabel}」に変更（場所: ${location.name}）`
+      : `ステータスを「${statusLabel}」に変更`;
+
+    const { log } = await insertShiftLocationLog({
+      userId,
+      locationId: location?.id ?? null,
+      locationNameSnapshot: location?.name ?? statusLabel,
+      latitudeSnapshot: location?.latitude ?? null,
+      longitudeSnapshot: location?.longitude ?? null,
+      actionType: LOCATION_ACTION_TYPES.statusChange,
+      operatedBy,
+      memo,
+    });
+
+    /* ログ書き込み失敗は警告に留め、操作自体は成功として返す */
+    return { currentLocation: data, log: log ?? null, error: null };
   } catch (error) {
     return { currentLocation: null, log: null, error };
   }


### PR DESCRIPTION
## Summary

PR #103（厚生部場所機能）に対するレビュー指摘事項の修正と機能改善。

### マップ実装の刷新
- ImageBackground + PanResponder の自前実装（713行）を **Leaflet CRS.Simple** に置き換え
- Web版: Leaflet を直接 DOM にマウント（iframe不使用で状態同期が確実）
- **ピンチズーム・パン操作**が標準対応（旧実装は未対応）
- Leaflet標準カラーマーカー（青/赤/緑/オレンジ）で視認性向上
- 画面サイズ変更時のマーカー位置ずれを解消

### ステータス管理機能（新機能）
- **配置中** / **巡回中** / **離席中** の3ステータスを追加
- 巡回中・離席中は場所に紐づかない（厚生部長が「誰が移動中か」を把握可能）
- DBマイグレーション + サービス関数 + 画面UI を追加
- 仕様書を v1.1 に更新

### バグ修正（PR #103 レビュー指摘対応）
- 一般厚生部員がマップでピン位置を変更できない問題
- エラーバナーがScrollView最下部で見えない問題
- 場所削除時の孤立レコード問題
- ログ書き込み失敗がエラーとして返される問題
- リアルタイム購読デバウンス追加
- その他複数のバグ修正

## Test plan

- [ ] 厚生部長ユーザーでログイン → 厚生部場所管理画面を開く
- [ ] 「ピン指定」モードでマップクリック → ドラフトピン表示
- [ ] 場所登録・編集・削除が正常動作
- [ ] 「自分の場所登録」で配置中/巡回中/離席中の切替
- [ ] 「現在地一覧」でステータス表示
- [ ] モバイルサイズでマーカー位置がずれない